### PR TITLE
Lens aberration function

### DIFF
--- a/diffractsim/diffractive_elements/lens.py
+++ b/diffractsim/diffractive_elements/lens.py
@@ -19,7 +19,7 @@ class Lens(DOE):
 
         t = 1
         if self.aberration != None:
-            t = t*bd.exp(2*bd.pi * 1j *aberration(xx, yy))
+            t = t*bd.exp(2j * bd.pi / λ * self.aberration(xx, yy))
 
         if self.radius != None:
             t = bd.where((xx**2 + yy**2) < self.radius**2, t, bd.zeros_like(xx))
@@ -62,7 +62,7 @@ class Lens(DOE):
             t = bd.ones_like(xx)
 
             if self.aberration != None:
-                t = t*bd.exp(2*bd.pi * 1j *aberration(xx, yy))
+                t = t*bd.exp(2*bd.pi * 1j * self.aberration(xx, yy))
 
             if self.radius != None:
                 t = t*bd.where((xx**2 + yy**2) < self.radius**2, t, bd.zeros_like(xx))

--- a/diffractsim/diffractive_elements/lens.py
+++ b/diffractsim/diffractive_elements/lens.py
@@ -6,7 +6,13 @@ from ..util.scaled_FT import scaled_fourier_transform
 class Lens(DOE):
     def __init__(self,f, radius = None, aberration = None):
         """
-        Creates a thin lens with a focal length equal to f 
+        Creates a thin lens with a focal length equal to f. 
+
+        Radius is a physical circular boundary of the lens.
+
+        Aberration is a function of (x, y) which describes the optical
+        path depth aberration of the lens. This is applied along with
+        any focal length given by `f`.
         """
         global bd
         from ..util.backend_functions import backend as bd

--- a/examples/lens_aberration.py
+++ b/examples/lens_aberration.py
@@ -1,0 +1,23 @@
+import diffractsim
+
+diffractsim.set_backend("CPU") #Change the string to "CUDA" to use GPU acceleration
+# Note: this example is highly recommendeded to run with CUDA
+
+from diffractsim import MonochromaticField, Lens, nm, mm, cm, GaussianBeam
+
+F = MonochromaticField(
+    wavelength=630 * nm, extent_x=20. * mm, extent_y=20. * mm, Nx=256, Ny=256,intensity = 1
+)
+F.add(GaussianBeam(1*mm))
+F.add(
+    Lens(
+        diffractsim.bd.Inf,
+        # equivalent OPD to a 50cm lens: -1/(2*f) r^2
+        aberration=lambda x,y: -1/(2*50*cm) * (x**2+y**2)
+    )
+)
+
+longitudinal_profile_rgb, longitudinal_profile_E, extent = F.get_longitudinal_profile( start_distance = 0*cm , end_distance = 100 *cm , steps = 80) 
+F.plot_longitudinal_profile_colors(longitudinal_profile_rgb = longitudinal_profile_rgb, extent = extent)
+print(longitudinal_profile_rgb.shape)
+


### PR DESCRIPTION
I noticed that the lens aberration attribute was not being referenced correctly (missing `self.`). I also added the missing wavelength dependence and a simple example showing how it can be used.