### PR TITLE
Fix field x and y extent in MonochromaticField and bluestein_method

### DIFF
--- a/diffractsim/monochromatic_simulator.py
+++ b/diffractsim/monochromatic_simulator.py
@@ -196,8 +196,8 @@ class MonochromaticField:
         self.xx, self.yy = bd.meshgrid(self.x, self.y)
         self.dx = self.x[1] - self.x[0]
         self.dy = self.y[1] - self.y[0]
-        self.extent_x = self.x[1] - self.x[0] + self.dx
-        self.extent_y = self.y[1] - self.y[0] + self.dy
+        self.extent_x = self.x[-1] - self.x[0] + self.dx
+        self.extent_y = self.y[-1] - self.y[0] + self.dy
         
         self.E = C*ft_factor * bd.exp(1j*bd.pi/(self.λ*focal_length)  * (self.xx**2 + self.yy**2)  +   1j*2*bd.pi/self.λ * focal_length ) / (1j*focal_length*self.λ)
         self.z += focal_length

--- a/diffractsim/propagation_methods/bluestein_method.py
+++ b/diffractsim/propagation_methods/bluestein_method.py
@@ -54,8 +54,8 @@ def bluestein_method(simulation, E, z, λ, x_interval, y_interval):
     simulation.dx = simulation.x[1] - simulation.x[0]
     simulation.dy = simulation.y[1] - simulation.y[0]
 
-    simulation.extent_x = simulation.x[1] - simulation.x[0] + simulation.dx
-    simulation.extent_y = simulation.y[1] - simulation.y[0] + simulation.dy
+    simulation.extent_x = simulation.x[-1] - simulation.x[0] + simulation.dx
+    simulation.extent_y = simulation.y[-1] - simulation.y[0] + simulation.dy
 
     return E*factor * bd.exp(1j*bd.pi/(λ*z)  * (simulation.xx**2 + simulation.yy**2)  +   1j*2*bd.pi/λ * z ) / (1j*z*λ)
 


### PR DESCRIPTION
Addresses indexing error in calculation of field extent in `MonochromaticField.propagate_to_lens_focal_plane` and `bluestein_method`.